### PR TITLE
Added api-key support/create-rest-api with no arguments will look in the environment

### DIFF
--- a/test/rally_api/api_test.clj
+++ b/test/rally_api/api_test.clj
@@ -8,10 +8,7 @@
 (def ^:dynamic *rest-api*)
 
 (defn api-fixture [f]
-  (let [username   (env/env :username)
-        password   (env/env :password)
-        rally-host (env/env :rally-host)
-        rest-api   (api/create-rest-api username password rally-host)]
+  (let [rest-api (api/create-rest-api)]
     (try
       (binding [*rest-api* rest-api]
         (f))


### PR DESCRIPTION
environment for credentials
