### PR TITLE
Separate rest-api creation from initialization

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.rallydev/clj-rally "0.8.3"
+(defproject com.rallydev/clj-rally "0.8.4"
   :description "A clojure library for interating with Rally's webservice API."
   :url "https://github.com/RallyTools/RallyRestAPIForClojure"
   :license {:name "MIT License"


### PR DESCRIPTION
Extracted a function, `create-basic-rest-api`, which does most of what
`create-rest-api` does, except that it does not make any calls to the
Rally server. This is to allow modification of the rest-api object
before calling the server.
