### PR TITLE
Remove middleware from rest-api object

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.rallydev/clj-rally "0.8.4"
+(defproject com.rallydev/clj-rally "0.9.0"
   :description "A clojure library for interating with Rally's webservice API."
   :url "https://github.com/RallyTools/RallyRestAPIForClojure"
   :license {:name "MIT License"


### PR DESCRIPTION
create-rest-api was adding clj-http's middleware to the returned object,
and then using clj-http.client/with-middleware when making calls. This
makes it impossible for the user to apply their own middleware with
`with-middleware`, because it would get overridden again in do-request.
