### PR TITLE
S126328: Update create! and update! to take optional query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,18 @@ that takes 2 parameters. The parameters are a type and a data map. The type is t
       (request/set-default-data-fn default-name)
       (api/create! rest-api :userstory)))
 ```
+If you want to pass request parameters such as fetch, pass them as a map:
+```clojure
+(api/create! rest-api :user-story {:name "This feature is really cool"} {:fetch :name})
+; => {:name "This feature is really cool",
+;     ...metadata... }
+```
 
 ### Updating Data
 ```clojure
 (def my-user-story (api/create! rest-api :user-story {:name "This feature is really cool"}))
 (api/update! rest-api my-user-story {:description "This is my description"})
+(api/update! rest-api my-user-story {:description "Only return name for the response"} {:fetch :name})
 ```
 
 #### Updating Collections

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.rallydev/clj-rally "0.11.0"
+(defproject com.rallydev/clj-rally "0.12.0"
   :description "A clojure library for interating with Rally's webservice API."
   :url "https://github.com/RallyTools/RallyRestAPIForClojure"
   :license {:name "MIT License"

--- a/src/rally/api.clj
+++ b/src/rally/api.clj
@@ -42,14 +42,20 @@
    (if (keyword? api-or-type)
      (create! *current-user* api-or-type type-or-data)
      (create! api-or-type type-or-data {})))
-  
-  ([rest-api type data]
+
+  ([api-or-type type-or-data data-or-query-params]
+   (if (keyword? api-or-type)
+     (create! *current-user* api-or-type type-or-data data-or-query-params)
+     (create! api-or-type type-or-data data-or-query-params {})))
+
+  ([rest-api type data query-params]
    {:pre [(valid-rest-api? rest-api)]}
    (let [default-data-fn (request/get-default-data-fn rest-api)]
      (-> rest-api
          (request/set-method :put)
          (request/set-uri type "create")
          (request/set-body-as-map type (default-data-fn type data))
+         (request/merge-query-params query-params)
          do-request
          :object))))
 
@@ -71,8 +77,13 @@
 (defn update!
   ([ref-or-object updated-data]
    (update! *current-user* ref-or-object updated-data))
-  
-  ([rest-api ref-or-object updated-data]
+
+  ([api-or-ref-or-object ref-or-object-or-updated-data updated-data-or-query-params]
+   (if (valid-rest-api? api-or-ref-or-object)
+     (update! api-or-ref-or-object ref-or-object-or-updated-data updated-data-or-query-params {})
+     (update! *current-user* api-or-ref-or-object ref-or-object-or-updated-data updated-data-or-query-params)))
+
+  ([rest-api ref-or-object updated-data query-params]
    {:pre [(valid-rest-api? rest-api)]}
    (let [ref  (data/->ref ref-or-object)
          type (or (:metadata/type ref-or-object) (data/rally-ref->clojure-type ref))]
@@ -80,6 +91,7 @@
          (request/set-method :post)
          (request/set-url ref)
          (request/set-body-as-map type updated-data)
+         (request/merge-query-params query-params)
          do-request
          :object))))
 

--- a/test/rally/api_test.clj
+++ b/test/rally/api_test.clj
@@ -21,8 +21,22 @@
 (deftest ^:integration objects-can-be-created-with-current-user
   (binding [api/*current-user* *rest-api*]
     (let [userstory-name (helper/generate-string)
-        userstory      (api/create! :userstory {:name userstory-name})]
+          userstory      (api/create! :userstory {:name userstory-name})]
       (is (= (:metadata/ref-object-name userstory) userstory-name)))))
+
+(deftest ^:integration objects-can-be-created-with-fetch-true-param
+  (let [userstory-name (helper/generate-string)
+        userstory      (-> *rest-api*
+                           (api/create! :userstory {:name userstory-name} {:fetch true}))]
+    (is (contains? userstory :name))
+    (is (contains? userstory :ready))))
+
+(deftest ^:integration objects-can-be-created-with-fetch-name-param
+  (binding [api/*current-user* *rest-api*]
+    (let [userstory-name (helper/generate-string)
+          userstory      (api/create! :userstory {:name userstory-name} {:fetch "Name"})]
+      (is (contains? userstory :name))
+      (is (not (contains? userstory :ready))))))
 
 (deftest ^:integration an-error-occurs-when-trying-to-create-object-without-binding-current-user
   (is (thrown? AssertionError (api/create! :userstory {:name (helper/generate-string)}))))
@@ -87,6 +101,21 @@
           _              (api/update! userstory {:name userstory-name})
           read-userstory (api/find-by-formatted-id *rest-api* :userstory (:formatted-id userstory))]
       (is (= (:metadata/ref-object-name read-userstory) userstory-name)))))
+
+(deftest ^:integration objects-can-be-updated-with-fetch-true-param
+  (let [userstory-name    (helper/generate-string)
+        userstory         (api/create! *rest-api* :userstory)
+        updated-userstory (api/update! *rest-api* userstory {:name userstory-name} {:fetch true})]
+    (is (contains? updated-userstory :name))
+    (is (contains? updated-userstory :ready))))
+
+(deftest ^:integration objects-can-be-updated-with-fetch-name-param
+  (binding [api/*current-user* *rest-api*]
+    (let [userstory-name    (helper/generate-string)
+          userstory         (api/create! *rest-api* :userstory)
+          updated-userstory (api/update! userstory {:name userstory-name} {:fetch "Name"})]
+      (is (contains? updated-userstory :name))
+      (is (not (contains? updated-userstory :ready))))))
 
 (deftest ^:integration an-error-occurs-when-trying-to-update-object-without-binding-current-user
   (is (thrown? AssertionError (api/update! :userstory {:name (helper/generate-string)}))))


### PR DESCRIPTION
In certain cases, a user will need to pass query/request parameters when doing a create or update. In particular, the rankAbove, rankBelow, and fetch parameters have their uses with create and update. 

This change will allow the user to pass a map of query parameters as an optional final parameter to the functions. The value for the fetch key (if present) will be transformed the same way it is done for reads and queries.