### PR TITLE
Troubleshooting output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ pom.xml.asc
 /.idea*
 *.iml
 *.swp
+
+.calva
+.clj-kondo/
+.lsp

--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ If you want to pass request parameters such as fetch, pass them as a map:
 ;     ...}
 ```
 
+## Troubleshooting
+
+To see debugging information, do one of the following:
+
+- Set a configuration variable such that `(environ.core/env :debug-rally-rest)` is true
+- Contrive to set the request :debug to true
+- Bind `rally.api/*debug*` to true
+
 ## License
 
 Copyright (c) Rally Software Development Corp. 2013-2015 Distributed under the MIT License.

--- a/project.clj
+++ b/project.clj
@@ -1,20 +1,21 @@
-(defproject com.rallydev/clj-rally "0.12.1"
+(defproject com.rallydev/clj-rally "0.12.2"
   :description "A clojure library for interating with Rally's webservice API."
   :url "https://github.com/RallyTools/RallyRestAPIForClojure"
   :license {:name "MIT License"
             :url  "http://en.wikipedia.org/wiki/MIT_License"}
   :deploy-repositories {"clojars" {:sign-releases false}}
-  :dependencies [[camel-snake-kebab "0.4.0"]
-                 [cheshire "5.8.1"]
-                 [clj-http "3.9.1"]
-                 [clj-time "0.15.1"]
-                 [environ "1.1.0"]
+  :dependencies [[camel-snake-kebab "0.4.3"]
+                 [cheshire "5.11.0"]
+                 [clj-http "3.12.3"]
+                 [clj-time "0.15.2"]
+                 [environ "1.2.0"]
                  [slingshot "0.12.2"]]
   :test-selectors {:default     (complement :integration)
                    :integration :integration}
-  :plugins [[lein-pprint "1.1.1"]]
+  :plugins [[lein-ancient "1.0.0-RC3"]
+            [lein-pprint "1.3.2"]]
   :profiles {:dev {:jvm-opts     ["-Xmx1g"]
                    :source-paths ["dev"]
                    :dependencies [[org.clojure/clojure "1.8.0"]
-                                  [criterium "0.4.4"]
-                                  [crypto-random "1.2.0"]]}})
+                                  [criterium "0.4.6"]
+                                  [crypto-random "1.2.1"]]}})

--- a/src/rally/api.clj
+++ b/src/rally/api.clj
@@ -1,14 +1,25 @@
 (ns rally.api
-  (:require [clj-http.client :as client]
+  (:require [cheshire.core :as json]
+            [clj-http.client :as client]
             [clj-http.conn-mgr :as conn-mgr]
             [clj-http.cookies :as cookies]
+            [clojure.pprint :refer [pprint]]
+            [clojure.string :refer [lower-case]]
             [environ.core :as env]
             [rally.api.data :as data]
-            [rally.api.request :as request])
-  (:use [slingshot.slingshot :only [throw+]])
+            [rally.api.request :as request]
+            [slingshot.slingshot :refer [throw+]])
   (:refer-clojure :exclude [find]))
 
 (def ^:dynamic *current-user*)
+
+(def ^:dynamic *debug* false)
+
+(defn- debug? [request]
+  (or *debug*
+      (= (lower-case (str (:debug request))) "true")
+      (= (lower-case (str (env/env :debug-rally-rest))) "true")
+      false))
 
 (defn- not-found? [error]
   (= error "Cannot find object to read"))
@@ -24,16 +35,31 @@
       (some not-found? errors)       nil
       :else                          (throw+ response "rally-errors: %s" errors))))
 
+(defn parse-response-body [response debug]
+  (try
+    (update response :body #(if (nil? %) % (json/parse-string % true)))
+    (catch Exception x
+      (debug (.printStackTrace x))
+      (merge response {:body {}
+                       :parse-exception x}))))
+
 (defn do-request [{:keys [request] :as api}]
-  (let [response (client/request request)]
-    (if (string? (:body response))
-      (check-for-rally-errors api response)
-      (->> response
-           :body
-           data/->clojure-map
-           vals
-           first
-           (check-for-rally-errors api)))))
+  (let [debug   (debug? request)
+        request (assoc request :debug debug)]
+    (when debug (pprint {:api     (dissoc api :request)
+                         :request request}))
+    (let [response (client/request request)
+          _        (when debug (pprint {:response response}))
+          response (parse-response-body response debug)
+          _        (when debug (pprint {:json (:body response)}))]
+      (if (string? (:body response))
+        (check-for-rally-errors api response)
+        (->> response
+             :body
+             data/->clojure-map
+             vals
+             first
+             (check-for-rally-errors api))))))
 
 (defn create!
   ([type] (create! *current-user* type {}))
@@ -229,9 +255,7 @@
                                       :headers            {"X-RallyIntegrationOS"       (env/env "os.name")
                                                            "X-RallyIntegrationPlatform" (env/env "java.version")
                                                            "X-RallyIntegrationLibrary"  "RallyRestAPIForClojure"}
-                                      :debug              (or (env/env :debug-rally-rest) false)
-                                      :method             :get
-                                      :as                 :json}
+                                      :method             :get}
                             :rally   {:host    rally-host
                                       :version :v2.0}}]
     (if api-key

--- a/src/rally/api.clj
+++ b/src/rally/api.clj
@@ -251,6 +251,8 @@
   [{:keys [api-key] :as credentials} rally-host conn-props]
   (let [connection-manager (conn-mgr/make-reusable-conn-manager conn-props)
         rest-api           {:request {:connection-manager connection-manager
+                                      ; avoid apache.http cookies warnings by using a standards compliant policy
+                                      :cookie-policy      :standard ; RFC 6265 (interoprability profile)
                                       :cookie-store       (cookies/cookie-store)
                                       :headers            {"X-RallyIntegrationOS"       (env/env "os.name")
                                                            "X-RallyIntegrationPlatform" (env/env "java.version")

--- a/src/rally/api/data.clj
+++ b/src/rally/api/data.clj
@@ -1,6 +1,5 @@
 (ns rally.api.data
   (:require [camel-snake-kebab.core :as csk]
-            [camel-snake-kebab.extras :as utils]
             [clj-time.coerce :as coerce]
             [clj-time.format :as format]
             [clojure.string :as string]
@@ -98,7 +97,7 @@
          p3
 
          ; /slm/webservice/v2.0/UserStory/1234
-         :default
+         :else
          p2)
         rally-type->clojure-type)))
 
@@ -141,7 +140,7 @@
          (map ->str)
          (string/join "/"))
 
-    :default
+    :else
     (->str (or (:metadata/ref ref-or-object) ref-or-object))))
 
 (defn uri-like? [thing]

--- a/src/rally/api/request.clj
+++ b/src/rally/api/request.clj
@@ -3,7 +3,6 @@
             [cheshire.generate :as encoding]
             [clj-time.coerce :as coerce]
             [clj-time.format :as format]
-            [clojure.string :as string]
             [rally.api.data :as data]))
 
 (encoding/add-encoder java.net.URI encoding/encode-str)


### PR DESCRIPTION
- add better troubleshooting output and config options

- remove "Invalid cookie header" warnings, like the one below, by using a standards-compliant cookie parser
```
Jun 07, 2023 3:29:53 PM org.apache.http.client.protocol.ResponseProcessCookies processCookies
WARNING: Invalid cookie header: "Set-Cookie: token=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT". Invalid 'expires' attribute: Thu, 01 Jan 1970 00:00:00 GMT
```